### PR TITLE
Update to 1.11.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 
 	ivy {
 		name = "ComputerCraft"
-		artifactPattern "http://addons-origin.cursecdn.com/files/2291/384/[module][revision](.[ext])"
+		artifactPattern "http://addons-origin.cursecdn.com/files/2311/39/[module][revision](.[ext])"
 	}
 
 	maven {
@@ -53,8 +53,10 @@ configurations {
 }
 
 dependencies {
-	compile "ComputerCraft:ComputerCraft:${cc_version}"
-	compile "org.squiddev:CCTweaks:${mc_version}-1.3.0:dev"
+	// We modify the CC jar so we cannot include it in the normal compile configuration
+	provided "ComputerCraft:ComputerCraft:${cc_version}"
+	testRuntime "ComputerCraft:ComputerCraft:${cc_version}"
+	compile "org.squiddev:CCTweaks:${mc_version}-1.3.1:dev"
 	compileOnly('org.squiddev:ConfigGen:1.2.5') { exclude group: 'net.minecraftforge' }
 
 	shade('org.squiddev:luaj.luajc:1.0.9') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-mc_version=1.8.9
-forge_version=11.15.1.1722
+mc_version=1.11.2
+forge_version=13.20.0.2226
 mod_version=1.0.0
-cc_version=1.79
-mappings=stable_20
+cc_version=1.80pr0
+mappings=snapshot_20161220

--- a/src/main/java/org/squiddev/cctweaks/runtimes/RuntimesMod.java
+++ b/src/main/java/org/squiddev/cctweaks/runtimes/RuntimesMod.java
@@ -17,7 +17,7 @@ import java.util.Map;
 	modid = RuntimesMod.ID,
 	name = RuntimesMod.NAME,
 	version = "${mod_version}",
-	dependencies = "required-after:ComputerCraft;",
+	dependencies = "required-after:computercraft;",
 	acceptedMinecraftVersions = "[1.8.9,]",
 	guiFactory = "org.squiddev.cctweaks.runtimes.GuiConfigFactory"
 )
@@ -46,7 +46,7 @@ public class RuntimesMod {
 
 	@SubscribeEvent
 	public void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent eventArgs) {
-		if (eventArgs.modID.equals(RuntimesMod.ID)) {
+		if (eventArgs.getModID().equals(RuntimesMod.ID)) {
 			org.squiddev.cctweaks.runtimes.ConfigForgeLoader.sync();
 		}
 	}

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -7,6 +7,6 @@
 		"url": "https://github.com/SquidDev-CC/CCTweaks-Runtimes",
 		"credits": "Dan200, Forge team, Luaj.org",
 		"authorList": [ "SquidDev" ],
-		"dependencies": [ "ComputerCraft", "CCTweaks" ]
+		"dependencies": [ "computercraft", "cctweaks" ]
 	}
 ]


### PR DESCRIPTION
I switched the dependency on ComputerCraft from a `compile` to a `provided` and a `testRuntime` (as in CCTweaks), I don't know if it's totally necessary though.